### PR TITLE
chore(vscode): use workspace typescript version by default

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib"
+}


### PR DESCRIPTION
Add VSCode settings file to ensure that we use the workspace version of Typescript. This will hopefully ensure that any candidates with an older version of Typescript installed globally (e.g. 4.x) don't get weird red squiggles.