### PR TITLE
fix(mock): support case-invariant search

### DIFF
--- a/mock/books.mock.ts
+++ b/mock/books.mock.ts
@@ -16,7 +16,7 @@ export default (): MockHandler[] => [
           return;
         }
         books = books.filter((b) => {
-          return b.title.toLowerCase().includes(req.query.q);
+          return b.title.toLowerCase().includes(req.query.q.toLowerCase());
         })
       }
       if (!books.length) {


### PR DESCRIPTION
The search currently only works if you type your search query in lower case i.e. "to kill a mockingbird" returns 1 result, but "To Kill a Mockingbird" returns 0 results.

This fix will ensure that the search is case invariant i.e. "To Kill a MoCkInGbIrD" would return 1 result.